### PR TITLE
Add macro to get time diff in seconds

### DIFF
--- a/host/include/host.h
+++ b/host/include/host.h
@@ -1,0 +1,13 @@
+#ifndef __HOST_H
+#define __HOST_H
+
+#include <sys/time.h>
+
+/* Everything in this file can be used on the host */
+
+#define TIME_DIFFERENCE(_start, _end) \
+    ((_end.tv_sec + _end.tv_usec / 1000000.0) - \
+    (_start.tv_sec + _start.tv_usec / 1000000.0))
+
+#endif	/* __HOST_H */
+


### PR DESCRIPTION
I noticed a few of us are doing this calculation, I [have it in PIM-HDC](https://github.com/UBC-ECE-Sasha/PIM-HDC/blob/03529a767a49ae34f2416a96492589b879fe162f/PIM_HDC/src/main.c#L57-L69) and while reviewing PIM-JSON I noticed the [same calculation being done](https://github.com/UBC-ECE-Sasha/PIM-JSON/blob/e976857bb471ef72519871636499d26e1498187a/sparser/sparser_dpu/dpu_host.c#L179-L181). Does it make sense to add a convenience macro?