### PR TITLE
Add macros for clock_gettime difference

### DIFF
--- a/host/include/host.h
+++ b/host/include/host.h
@@ -6,8 +6,17 @@
 /* Everything in this file can be used on the host */
 
 #define TIME_DIFFERENCE(_start, _end) \
-    ((_end.tv_sec + _end.tv_usec / 1000000.0) - \
-    (_start.tv_sec + _start.tv_usec / 1000000.0))
+    ((_end.tv_sec + _end.tv_nsec / 1.0e9) - \
+    (_start.tv_sec + _start.tv_nsec / 1.0e9))
+
+#define TIME_DIFFERENCE_NSEC(_start, _end) \
+    ((_end.tv_nsec < _start.tv_nsec)) ? \
+    ((_end.tv_sec - 1 - (_start.tv_sec)) * 1e9 + _end.tv_nsec + 1e9 - _start.tv_nsec) : \
+    ((_end.tv_sec - (_start.tv_sec)) * 1e9 + _end.tv_nsec - _start.tv_nsec)
+
+#define TIME_DIFFERENCE_GETTIMEOFDAY(_start, _end) \
+    ((_end.tv_sec + _end.tv_usec / 1.0e6) - \
+    (_start.tv_sec + _start.tv_usec / 1.0e6))
 
 #endif	/* __HOST_H */
 


### PR DESCRIPTION
Renames existing macro for `gettimeofday` `TIME_DIFFERENCE_GETTIMEOFDAY`, in case anyone still wants to use it.

Introduces a new macro `TIME_DIFFERENCE` which behaves the same as the prior one but is for `clock_gettime`.

Adds a new macro `TIME_DIFFERENCE_NSEC` which returns the time in nanoseconds. Calculation taken from https://github.com/UBC-ECE-Sasha/PIM-common/issues/3#issuecomment-667228484

Fixes #3