### PR TITLE
Add macros for metric prefixes and some hardware details

### DIFF
--- a/common/include/common.h
+++ b/common/include/common.h
@@ -20,6 +20,9 @@ bottom 12 bits (0xFFF) use: BITMASK(12) */
 #define GIGABYTE(_X) (_x << 30)
 #define TERABYTE(_X) (_x << 40)
 
+#define WRAM_SIZE KILOBYTE(64)
+#define MRAM_SIZE MEGABYTE(64)
+
 /* If you have a value that needs alignment to the nearest _width. For example,
 0xF283 needs aligning to the next largest multiple of 16: 
 ALIGN(0xF283, 16) will return 0xF290 */

--- a/common/include/common.h
+++ b/common/include/common.h
@@ -15,7 +15,10 @@ bottom 12 bits (0xFFF) use: BITMASK(12) */
 #define MAX(_a, _b) (_a > _b ? _a : _b)
 
 /* Make large numbers easier to read (and accurate) */
+#define KILOBYTE(_x) (_x << 10)
 #define MEGABYTE(_x) (_x << 20)
+#define GIGABYTE(_X) (_x << 30)
+#define TERABYTE(_X) (_x << 40)
 
 /* If you have a value that needs alignment to the nearest _width. For example,
 0xF283 needs aligning to the next largest multiple of 16: 

--- a/common/include/common.h
+++ b/common/include/common.h
@@ -17,8 +17,8 @@ bottom 12 bits (0xFFF) use: BITMASK(12) */
 /* Make large numbers easier to read (and accurate) */
 #define KILOBYTE(_x) (_x << 10)
 #define MEGABYTE(_x) (_x << 20)
-#define GIGABYTE(_X) (_x << 30)
-#define TERABYTE(_X) (_x << 40)
+#define GIGABYTE(_x) (_x << 30)
+#define TERABYTE(_x) (_x << 40)
 
 #define WRAM_SIZE KILOBYTE(64)
 #define MRAM_SIZE MEGABYTE(64)


### PR DESCRIPTION
I don't think anyone needs the `TERABYTE()` macro, but I added it for completeness and future-proofing.